### PR TITLE
fix: compile gcc 11 armch64

### DIFF
--- a/include/version.h
+++ b/include/version.h
@@ -11,8 +11,8 @@
 extern "C" {
 #endif
 
-const char* gVERSION;
-const char* gVERSION_SHORT;
+extern const char* gVERSION;
+extern const char* gVERSION_SHORT;
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
- Correction of name overposition errors
``` sh

/home/castro/kernel-rock/gcc-linaro-11.3.1-2022.06-x86_64_aarch64-linux-gnu/bin/../lib/gcc/aarch64-linux-gnu/11.3.1/../../../../aarch64-linux-gnu/bin/ld: CMakeFiles/mraa.dir/version.c.o:(.data.rel.local+0x0): multiple definition of `gVERSION'; CMakeFiles/mraa.dir/mraa.c.o:(.bss+0x0): first defined here
/home/castro/kernel-rock/gcc-linaro-11.3.1-2022.06-x86_64_aarch64-linux-gnu/bin/../lib/gcc/aarch64-linux-gnu/11.3.1/../../../../aarch64-linux-gnu/bin/ld: CMakeFiles/mraa.dir/version.c.o:(.data.rel.local+0x8): multiple definition of `gVERSION_SHORT'; CMakeFiles/mraa.dir/mraa.c.o:(.bss+0x8): first defined here
collect2: error: ld returned 1 exit status
gmake[2]: *** [src/CMakeFiles/mraa.dir/build.make:594: src/libmraa.so.2.1.0] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:319: src/CMakeFiles/mraa.dir/all] Error 2
gmake: *** [Makefile:146: all] Error 2
➜  mraa git:(master) ✗ 
```